### PR TITLE
Additional hardware-specific examples

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -6,6 +6,9 @@
             "compilerPath": "C:/Program Files/DaisyToolchain/bin/arm-none-eabi-gcc.exe",
             "includePath": [
                 "${workspaceFolder}/BasicExample/**",
+                "${workspaceFolder}/PassthruAndBypass/**",
+                "${workspaceFolder}/SimplePotReading/**",
+                "${workspaceFolder}/SimpleSwitchReading/**",
                 "${workspaceFolder}/libs/libDaisy/**",
                 "${workspaceFolder}/libs/DaisySP/**"
             ],
@@ -24,6 +27,9 @@
             "compilerPath": "/usr/bin/arm-none-eabi-gcc",
             "includePath": [
                 "${workspaceFolder}/BasicExample/**",
+                "${workspaceFolder}/PassthruAndBypass/**",
+                "${workspaceFolder}/SimplePotReading/**",
+                "${workspaceFolder}/SimpleSwitchReading/**",
                 "${workspaceFolder}/libs/libDaisy/**",
                 "${workspaceFolder}/libs/DaisySP/**"
             ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
         "reset init",
         "gdb_breakpoint_override hard"
       ],
-      "preLaunchTask": "Build",
+      "preLaunchTask": "BasicExample - Build",
       "preRestartCommands": [
         "load",
         "enable breakpoint",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -32,6 +32,15 @@
       "problemMatcher": [],
       "type": "shell"
     },
+    {
+      "label": "Program-DFU",
+      "command": "make program-dfu",
+      "options": {
+        "cwd": "${fileDirname}"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
     // BasicExample Tasks
     {
       "label": "BasicExample - Build",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,8 +9,9 @@
       "problemMatcher": [],
       "type": "shell"
     },
+    // BasicExample Tasks
     {
-      "label": "Build",
+      "label": "BasicExample - Build",
       "command": "make",
       "options": {
         "cwd": "${workspaceFolder}/BasicExample"
@@ -19,7 +20,7 @@
       "type": "shell"
     },
     {
-      "label": "Clean",
+      "label": "BasicExample - Clean",
       "command": "make clean",
       "options": {
         "cwd": "${workspaceFolder}/BasicExample"
@@ -28,7 +29,7 @@
       "type": "shell"
     },
     {
-      "label": "Program DFU",
+      "label": "BasicExample - Program DFU",
       "command": "make program-dfu",
       "options": {
         "cwd": "${workspaceFolder}/BasicExample"
@@ -37,13 +38,134 @@
       "type": "shell"
     },
     {
-      "label": "Rebuild and Program DFU",
+      "label": "BasicExample - Rebuild and Program DFU",
       "command": "make clean; make; make program-dfu",
       "options": {
         "cwd": "${workspaceFolder}/BasicExample"
       },
       "problemMatcher": [],
       "type": "shell"
+    },
+    // SimplePotReading Tasks
+    {
+      "label": "SimplePotReading - Build",
+      "command": "make",
+      "options": {
+        "cwd": "${workspaceFolder}/SimplePotReading"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "label": "SimplePotReading - Clean",
+      "command": "make clean",
+      "options": {
+        "cwd": "${workspaceFolder}/SimplePotReading"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "label": "SimplePotReading - Program DFU",
+      "command": "make program-dfu",
+      "options": {
+        "cwd": "${workspaceFolder}/SimplePotReading"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "label": "SimplePotReading - Rebuild and Program DFU",
+      "command": "make clean; make; make program-dfu",
+      "options": {
+        "cwd": "${workspaceFolder}/SimplePotReading"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    // SimpleSwitchReading Tasks
+    {
+      "label": "SimpleSwitchReading - Build",
+      "command": "make",
+      "options": {
+        "cwd": "${workspaceFolder}/SimpleSwitchReading"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "label": "SimpleSwitchReading - Clean",
+      "command": "make clean",
+      "options": {
+        "cwd": "${workspaceFolder}/SimpleSwitchReading"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "label": "SimpleSwitchReading - Program DFU",
+      "command": "make program-dfu",
+      "options": {
+        "cwd": "${workspaceFolder}/SimpleSwitchReading"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "label": "SimpleSwitchReading - Rebuild and Program DFU",
+      "command": "make clean; make; make program-dfu",
+      "options": {
+        "cwd": "${workspaceFolder}/SimpleSwitchReading"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    // PassthruAndBypass Tasks
+    {
+      "label": "PassthruAndBypass - Build",
+      "command": "make",
+      "options": {
+        "cwd": "${workspaceFolder}/PassthruAndBypass"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "label": "PassthruAndBypass - Clean",
+      "command": "make clean",
+      "options": {
+        "cwd": "${workspaceFolder}/PassthruAndBypass"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "label": "PassthruAndBypass - Program DFU",
+      "command": "make program-dfu",
+      "options": {
+        "cwd": "${workspaceFolder}/PassthruAndBypass"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "label": "PassthruAndBypass - Rebuild and Program DFU",
+      "command": "make clean; make; make program-dfu",
+      "options": {
+        "cwd": "${workspaceFolder}/PassthruAndBypass"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "label": "Build All",
+      "dependsOn": ["BasicExample - Build", "PassthruAndBypass - Build",
+                    "SimplePotReading - Build", "SimpleSwitchReading - Build"] 
+    },
+    {
+      "label": "Clean All",
+      "dependsOn": ["BasicExample - Clean", "PassthruAndBypass - Clean",
+                    "SimplePotReading - Clean", "SimpleSwitchReading - Clean"] 
     }
   ],
   "version": "2.0.0"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,6 +9,29 @@
       "problemMatcher": [],
       "type": "shell"
     },
+    // Tasks for operations on the selected file's example.
+    {
+      "label": "Build",
+      "command": "make",
+      "options": {
+        "cwd": "${fileDirname}"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "label": "Clean",
+      "command": "make clean",
+      "options": {
+        "cwd": "${fileDirname}"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
     // BasicExample Tasks
     {
       "label": "BasicExample - Build",
@@ -157,6 +180,7 @@
       "problemMatcher": [],
       "type": "shell"
     },
+    // Combined Tasks for doing operations on all examples.
     {
       "label": "Build All",
       "dependsOn": ["BasicExample - Build", "PassthruAndBypass - Build",

--- a/PassthruAndBypass/Makefile
+++ b/PassthruAndBypass/Makefile
@@ -1,0 +1,22 @@
+# Project Name
+TARGET = BasicExample
+
+# Configure for debugging
+# common configurations:
+# use DEBUG = 1 and OPT = -Og for debugging
+# or DEBUG = 0 and OPT = -O3 for performance
+DEBUG = 0
+OPT = -O3
+
+# Sources
+CPP_SOURCES = main.cpp
+
+LIBDAISY_DIR = ../libs/libDaisy
+DAISYSP_DIR = ../libs/DaisySP
+
+# (optional) Includes FatFS source files within project.
+#USE_FATFS = 1
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/PassthruAndBypass/Makefile
+++ b/PassthruAndBypass/Makefile
@@ -1,5 +1,5 @@
 # Project Name
-TARGET = BasicExample
+TARGET = PassthruAndBypass
 
 # Configure for debugging
 # common configurations:

--- a/PassthruAndBypass/main.cpp
+++ b/PassthruAndBypass/main.cpp
@@ -1,0 +1,78 @@
+/** Daisy Seed2 DFM Pedal Dev Kit Basic Example
+ *
+ *  This example does a few things that can serve as a great jumping off
+ *  point for new effects pedal projects.
+ *
+ *  1. Initializes Switch and GPIO for control of the true-bypass relays
+ *  2. Initializes an LED to indicate bypass state (illuminate RED when audio runs through software)
+ *  3. Sets up basic audio passthru
+ */
+#include "daisy_seed.h"
+
+using namespace daisy;
+
+/** Global objects that need to be accessed in both main() and the audio callback */
+DaisySeed hardware;
+
+/** The audio callback that fires whenever new audio samples can be prepared */
+void AudioCallback(AudioHandle::InputBuffer in,
+                   AudioHandle::OutputBuffer out,
+                   size_t size)
+{
+    for (size_t i = 0; i < size; i++)
+    {
+        /** For each sample in the loop we'll multiply the input by our volume control
+         *  OUT_x and IN_x are macros that access the out, and in buffers respectively.
+         *  This would be equivalent to: out[0][i] = in[0][i] * volume;, etc.
+         */
+        OUT_L[i] = IN_L[i];
+        OUT_R[i] = IN_R[i];
+
+        /** Due to minor errata on the Rev4 hardware we need to phase invert the
+         *  left channel so both outputs have the same phase */
+        OUT_L[i] *= -1.f;
+    }
+}
+
+int main()
+{
+
+    /** Initialize the Daisy Seed at maximum clock speed */
+    hardware.Init(true);
+
+    /** Relay Control/UI init */
+    GPIO relay_left, relay_right;
+    Switch relay_control;
+    Led relay_led;
+    relay_left.Init(seed::D20, GPIO::Mode::OUTPUT);
+    relay_right.Init(seed::D21, GPIO::Mode::OUTPUT);
+    relay_control.Init(seed::D23, hardware.AudioCallbackRate());
+    relay_led.Init(seed::D11, true);
+
+    /** Start the Audio */
+    hardware.StartAudio(AudioCallback);
+
+    while (true)
+    {
+        /** Debounce the toggle */
+        relay_control.Debounce();
+
+        /** Update the relay states based on the toggle position */
+        bool bypass_state = relay_control.Pressed();
+        relay_left.Write(bypass_state);
+        relay_right.Write(bypass_state);
+
+        /** Update the LED brightness based on true bypass state */
+        if (bypass_state)
+            relay_led.Set(1);
+        else
+            relay_led.Set(0);
+        /** Update the LED (required in case of software PWM for values between 0-1)*/
+        relay_led.Update();
+
+        /** We'll delay for one millisecond before looping back over to keep everything nice, and predictable
+         *  The hardware control work could be moved to the audio callback as well.
+         */
+        System::Delay(1);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Includes:
 * SimplePotReading - Exmaple demonstrating reading two pots, and printing their values to a serial monitor.
 * SimpleSwitchReading - Example demonstrating reading the position of a toggle.
 
+When you have the Makefile, or a source file within an examples folder open, you can run the "Build task" with "ctrl-shift-B" on windows, or "cmd-shift-B" on Mac OS, and that will compile the selected example.
+
 For each of these examples, there are the following VS code tasks:
 
 * Build: build the specified example
@@ -36,7 +38,7 @@ For each of these examples, there are the following VS code tasks:
 * Program DFU: programs the specified example's binary file via USB
 * Build and Program DFU: Rebuilds the specified program and downloads it via USB DFU
 
-In addition, there is a global VS Code task:
+In addition, there is a set of tasks that will operate on the entire workspace:
 
 * Build Libraries: builds libDaisy, and DaisySP from scratch. This is only necessary when manually updating, or cloning for the first time.
 * Build All: builds all of the individual example projects.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Includes:
 * SimpleSwitchReading - Example demonstrating reading the position of a toggle.
 
 When you have the Makefile, or a source file within an examples folder open, you can run the "Build task" with "ctrl-shift-B" on windows, or "cmd-shift-B" on Mac OS, and that will compile the selected example.
+A similar, generic set of tasks for "Clean" and "Program DFU" are also available for the selected example.
 
 For each of these examples, there are the following VS code tasks:
 

--- a/README.md
+++ b/README.md
@@ -25,16 +25,24 @@ Includes:
 * libDaisy - hardware library for Daisy
 * DaisySP - DSP library
 * BasicExample - Basic example demonstrating hardware setup code for the dev kit hardware.
+* PassthruAndBypass - Example demonstrating toggling between audio passthru and true bypass
+* SimplePotReading - Exmaple demonstrating reading two pots, and printing their values to a serial monitor.
+* SimpleSwitchReading - Example demonstrating reading the position of a toggle.
 
-This also contains the following VS code tasks:
+For each of these examples, there are the following VS code tasks:
+
+* Build: build the specified example
+* Clean: removes the specified example's build folder, and it's contents.
+* Program DFU: programs the specified example's binary file via USB
+* Build and Program DFU: Rebuilds the specified program and downloads it via USB DFU
+
+In addition, there is a global VS Code task:
 
 * Build Libraries: builds libDaisy, and DaisySP from scratch. This is only necessary when manually updating, or cloning for the first time.
-* Build: build the blink example
-* Clean: removes compiled BasicExample code
-* Program DFU: programs the BasicExample.bin file via USB
-* Build and Program DFU: Rebuilds the program and downloads it via USB DFU
+* Build All: builds all of the individual example projects.
+* Clean All: removes all examples' build folders, and their contents.
 
-In addition, the following debug configurations are available:
+The following debug configurations are available:
 
 * Debug BasicExample: debugs the BasicExample application
 

--- a/SimplePotReading/Makefile
+++ b/SimplePotReading/Makefile
@@ -1,5 +1,5 @@
 # Project Name
-TARGET = BasicExample
+TARGET = SimplePotReading
 
 # Configure for debugging
 # common configurations:

--- a/SimplePotReading/Makefile
+++ b/SimplePotReading/Makefile
@@ -1,0 +1,22 @@
+# Project Name
+TARGET = BasicExample
+
+# Configure for debugging
+# common configurations:
+# use DEBUG = 1 and OPT = -Og for debugging
+# or DEBUG = 0 and OPT = -O3 for performance
+DEBUG = 0
+OPT = -O3
+
+# Sources
+CPP_SOURCES = main.cpp
+
+LIBDAISY_DIR = ../libs/libDaisy
+DAISYSP_DIR = ../libs/DaisySP
+
+# (optional) Includes FatFS source files within project.
+#USE_FATFS = 1
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/SimplePotReading/main.cpp
+++ b/SimplePotReading/main.cpp
@@ -1,0 +1,41 @@
+/** Daisy Seed2 DFM Pedal Dev Kit Basic Example
+ *
+ *  In this example we set up two pots, and print their values over serial.
+ *  To see the serial data printing on your computer, you can use any serial monitor
+ *  (Serial Monitor extension in VS Code, Arduino Serial Monitor, PutTy, etc.) 
+ */
+#include "daisy_seed.h"
+
+using namespace daisy;
+
+/** Global objects that need to be accessed in both main() and the audio callback */
+DaisySeed hardware;
+
+int main()
+{
+
+    /** Initialize the Daisy Seed at maximum clock speed */
+    hardware.Init(true);
+
+    /** ADC and Volume Control setup */
+    AdcChannelConfig adc_cfg[2];
+    adc_cfg[0].InitSingle(seed::A0); /**< alias for seed::D15 */
+    adc_cfg[1].InitSingle(seed::A1); /**< alias for seed::D16 */
+    hardware.adc.Init(adc_cfg, 2);
+
+    /** Start the serial logger, and the ADC */
+    hardware.StartLog();
+    hardware.adc.Start();
+
+
+    while (true)
+    {
+        /** Every 100ms print the data,
+         *  the basic adc.Get function will return a value from 0-65535 
+         */
+        hardware.PrintLine("--- Pot Data ---");
+        hardware.PrintLine("POT 1:\t%d", hardware.adc.Get(0));
+        hardware.PrintLine("POT 2:\t%d", hardware.adc.Get(1));
+        System::Delay(100);
+    }
+}

--- a/SimpleSwitchReading/Makefile
+++ b/SimpleSwitchReading/Makefile
@@ -1,0 +1,22 @@
+# Project Name
+TARGET = BasicExample
+
+# Configure for debugging
+# common configurations:
+# use DEBUG = 1 and OPT = -Og for debugging
+# or DEBUG = 0 and OPT = -O3 for performance
+DEBUG = 0
+OPT = -O3
+
+# Sources
+CPP_SOURCES = main.cpp
+
+LIBDAISY_DIR = ../libs/libDaisy
+DAISYSP_DIR = ../libs/DaisySP
+
+# (optional) Includes FatFS source files within project.
+#USE_FATFS = 1
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/SimpleSwitchReading/Makefile
+++ b/SimpleSwitchReading/Makefile
@@ -1,5 +1,5 @@
 # Project Name
-TARGET = BasicExample
+TARGET = SimpleSwitchReading
 
 # Configure for debugging
 # common configurations:

--- a/SimpleSwitchReading/main.cpp
+++ b/SimpleSwitchReading/main.cpp
@@ -1,0 +1,40 @@
+/** Daisy Seed2 DFM Pedal Dev Kit Basic Example
+ *
+ *  This example does a few things that can serve as a great jumping off
+ *  point for new effects pedal projects.
+ *
+ *  1. Initializes Switch and GPIO for control of the true-bypass relays
+ *  2. Initializes an LED to indicate bypass state (illuminate RED when audio runs through software)
+ *  3. Initializes POT 1 and 2 to be used to control the volume of the audio channels
+ *  4. Sets up basic audio with volume control via POT 1 and 2
+ */
+#include "daisy_seed.h"
+
+using namespace daisy;
+
+/** Global objects that need to be accessed in both main() and the audio callback */
+DaisySeed hardware;
+
+int main()
+{
+
+    /** Initialize the Daisy Seed at maximum clock speed */
+    hardware.Init(true);
+
+    Switch toggle;
+    toggle.Init(seed::D23, hardware.AudioCallbackRate());
+
+    hardware.StartLog();
+
+    while (true)
+    {
+        bool toggle_state = toggle.RawState();
+        if (toggle_state)
+            hardware.PrintLine("Toggle On");
+        else
+            hardware.PrintLine("Toggle Off");
+
+        /** Delay 100ms and then repeat */
+        System::Delay(100);
+    }
+}


### PR DESCRIPTION
This adds three new examples:

* PassthruAndBypass - an example demonstrating relay control, and audio pass thru.
* SimplePotReading - an example demonstrating setting up, and reading two pots on the hardware.
* SimpleSwitchReading - an example demonstrating setting up, and reading the position of a two way toggle.

In addition, I added a generic "Build" task that is the default build command from VS code. This task will build an example that has it's source files selected in the editor.
There are also similar generic tasks for "clean" and "program-dfu".

Other changes include:

* Updates to the README to include information about all VS code tasks, and the new examples
* Additional clean, build, and program tasks for all examples, as well as tasks that will clean or build all examples at once.